### PR TITLE
nostr-toolsのバージョンを1.13.1に固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sub-reply": "node scripts/sub_reply.js"
   },
   "dependencies": {
-    "nostr-tools": "^1.11.1",
+    "nostr-tools": "1.13.1",
     "websocket-polyfill": "^0.0.3"
   }
 }


### PR DESCRIPTION
1.14.0における `Relay#publish()`のシグネチャの破壊的変更への対応

cf. https://github.com/nbd-wtf/nostr-tools/releases/tag/v1.14.0

> yes, I don't understand semver

¯\\\_(ツ)\_/¯
